### PR TITLE
Change colors_name to "sourcerer"

### DIFF
--- a/vim/.vim/colors/sourcerer.vim
+++ b/vim/.vim/colors/sourcerer.vim
@@ -18,7 +18,7 @@ if exists("syntax_on")
   syntax reset
 endif
 
-let colors_name = "sorcerer"
+let colors_name = "sourcerer"
 
 " GUI Colors {{{1
 " ============================================================================


### PR DESCRIPTION
Changed colors_name from "sorcerer" to "sourcerer" to fix an error message if the sorcerer color scheme isn't installed. Also because the name of the scheme is sourcerer :)