### PR TITLE
Fix vim style copy paste keybindings for tmux 2.4

### DIFF
--- a/tmux/.tmux.conf
+++ b/tmux/.tmux.conf
@@ -46,8 +46,10 @@ unbind [
 bind Escape copy-mode
 unbind p
 bind p paste-buffer
-bind-key -t vi-copy 'v' begin-selection
-bind -t vi-copy y copy-pipe 'xclip -in -selection clipboard'
+bind-key -T copy-mode-vi 'v' send -X begin-selection
+bind-key -T copy-mode-vi 'y' send -X copy-pipe-and-cancel \
+    "xclip -in -selection clipboard > /dev/null"\; \
+    display-message "Copied selection to clipboard"
 
 # use vi mode
 setw -g mode-keys vi


### PR DESCRIPTION
tmux 2.4 introduced some incompatible changes (mode key tables removed).

Also, since xclip doesn't close STDOUT after reading from tmux's buffer, I piped it to /dev/null to prevent a hang.